### PR TITLE
increase min electron version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "prettier-eslint-cli": "^4.4.0"
   },
   "peerDepencies": {
-    "electron": "^1.8.1"
+    "electron": "^1.8.2"
   }
 }


### PR DESCRIPTION
I believe async calls require node version 7.6 or higher.  electron 1.8.2 bumped node version to include node ^7.6 (see https://github.com/electron/electron/commit/0330a30fdb405d99cddaf2b0529f9ea02086d949#diff-bcf7bcf05ac59e51b9adfd7394c810c4)

When I tried installing electron-push-receiver and running I was getting unexpected token errors on async calls.