### PR TITLE
Don't send messages to destroyed webContents

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,8 +36,10 @@ function setup(webContents) {
     // Retrieve saved senderId
     const savedSenderId = config.get('senderId');
     if (started) {
-      if (!webContents.isDestroyed()) {
+      try {
         webContents.send(NOTIFICATION_SERVICE_STARTED, (credentials.fcm || {}).token);
+      } catch (e) {
+        console.error('PUSH_RECEIVER:::Error while sending to webContents', e);
       }
       return;
     }
@@ -89,11 +91,11 @@ function removeWebContents(webContents) {
 
 function send(channel, arg1) {
   webContentses.forEach((webContents) => {
-    if (webContents.isDestroyed()) {
-      // sending to a destroyed web contents crashes the process, so be safe
-      return
+    try {
+      webContents.send(channel, arg1)
+    } catch (e) {
+      console.error('PUSH_RECEIVER:::Error while sending to webContents', e);
     }
-    webContents.send(channel, arg1)
   })
 }
 


### PR DESCRIPTION
This commit:
1. Prevents sending messages to destroyed webContents (which result in a crash)
2. Allows registering multiple webContents for push notifications

We need this because we are listening for notifcations in a specific
webContents. If it crashes we create a new one and call setup again,
without this change the next push notification that came in would cause
a crash.