### PR TITLE
Added code to allow app to reload config settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ There are cases where you may need to reset the push receiver to a state where i
 One solution is to simply delete the cache and restart the app using Electron's API. But this is not always desirable. If you want to avoid clearing your app's cache and don't want to restart the app, you can call the reset method on the push receiver. This will have to be called from the renderer process back into the main prcoess. Here is an example of how to setup a callback in the main process:
 
 ```javascript
+var mPushReceiver;
+
 ipcRenderer.on('resetPushReceiver', (event, arg) => {
-    pushReceiver.reset();
+    mPushReceiver.reset();
 })
 ```
 Then in your renderer process:
@@ -68,7 +70,10 @@ If you don't plan on restarting your app, you will have to call the setupPushRec
 
 ```javascript
 ipcRenderer.on('startPushReceiver', (event, arg) => {
-    pushReceiver.setup(mMainWindow.webContents);
+    if (mPushReceiver ==  null) {
+        mPushReceiver = require('electron-push-receiver');
+        mPushReceiver.setup(mMainWindow.webContents);
+    }
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ npm i -S electron-push-receiver
 - In `main.js` / in main process :
 
 ```javascript
-const { setup: setupPushReceiver } = require('electron-push-receiver');
+const pushReceiver = require('electron-push-receiver');
 
 // Call it before 'did-finish-load' with mainWindow a reference to your window
-setupPushReceiver(mainWindow.webContents);
+pushReceiver.setupPushReceiver(mainWindow.webContents);
 ```
 
 - In renderer process :
@@ -45,6 +45,38 @@ ipcRenderer.on(TOKEN_UPDATED, (_, token) => // Send token);
 ipcRenderer.on(ON_NOTIFICATION_RECEIVED, (_, notification) => // display notification);
 // Start service
 ipcRenderer.send(START_NOTIFICATION_SERVICE, senderId);
+```
+<br>
+### Reseting the Push Receiver
+There are cases where you may need to reset the push receiver to a state where it retrieves a new notification token from FCM. For instance,if your app is designed to support a sign in screen and you only want push notifications for the person who signs in, you will need to have the push receiver delete the notification token when a different person signs in, otherwise it is possible that the new sign in receives notifications that are only private to the person who signed in previously.
+
+One solution is to simply delete the cache and restart the app using Electron's API. But this is not always desirable. If you want to avoid clearing your app's cache and don't want to restart the app, you can call the reset method on the push receiver. This will have to be called from the renderer process back into the main prcoess. Here is an example of how to setup a callback in the main process:
+
+```javascript
+ipcRenderer.on('resetPushReceiver', (event, arg) => {
+    pushReceiver.reset();
+})
+```
+Then in your renderer process:
+
+```javascript
+ const {ipcRenderer} = require('electron');
+ ipcRenderer.send('resetPushReceiver', null);
+```
+
+If you don't plan on restarting your app, you will have to call the setupPushReceiver method again from our renderer process. So in your main process, you would need to setup another callback first:
+
+```javascript
+ipcRenderer.on('startPushReceiver', (event, arg) => {
+    pushReceiver.setup(mMainWindow.webContents);
+})
+```
+
+And then call it from your renderer process:
+
+```javascript
+const {ipcRenderer} = require('electron');
+ ipcRenderer.send('startPushReceiver', null);
 ```
 
 ## Example

--- a/src/index.js
+++ b/src/index.js
@@ -1,23 +1,24 @@
-const { register, listen } = require('push-receiver');
-const { ipcMain } = require('electron');
+const {register, listen} = require('push-receiver');
+const {ipcMain} = require('electron');
 const Config = require('electron-config');
 const {
-  START_NOTIFICATION_SERVICE,
-  NOTIFICATION_SERVICE_STARTED,
-  NOTIFICATION_SERVICE_ERROR,
-  NOTIFICATION_RECEIVED,
-  TOKEN_UPDATED,
+    START_NOTIFICATION_SERVICE,
+    NOTIFICATION_SERVICE_STARTED,
+    NOTIFICATION_SERVICE_ERROR,
+    NOTIFICATION_RECEIVED,
+    TOKEN_UPDATED,
 } = require('./constants');
 
 const config = new Config();
 
 module.exports = {
-  START_NOTIFICATION_SERVICE,
-  NOTIFICATION_SERVICE_STARTED,
-  NOTIFICATION_SERVICE_ERROR,
-  NOTIFICATION_RECEIVED,
-  TOKEN_UPDATED,
-  setup,
+    START_NOTIFICATION_SERVICE,
+    NOTIFICATION_SERVICE_STARTED,
+    NOTIFICATION_SERVICE_ERROR,
+    NOTIFICATION_RECEIVED,
+    TOKEN_UPDATED,
+    setup,
+    reset
 };
 
 // To be sure that start is called only once
@@ -25,49 +26,65 @@ let started = false;
 
 // To be call from the main process
 function setup(webContents) {
-  // Will be called by the renderer process
-  ipcMain.on(START_NOTIFICATION_SERVICE, async (_, senderId) => {
-    // Retrieve saved credentials
-    let credentials = config.get('credentials');
-    // Retrieve saved senderId
-    const savedSenderId = config.get('senderId');
-    if (started) {
-      webContents.send(NOTIFICATION_SERVICE_STARTED, (credentials.fcm || {}).token);
-      return;
-    }
-    started = true;
-    try {
-      // Retrieve saved persistentId : avoid receiving all already received notifications on start
-      const persistentIds = config.get('persistentIds') || [];
-      // Register if no credentials or if senderId has changed
-      if (!credentials || savedSenderId !== senderId) {
-        credentials = await register(senderId);
-        // Save credentials for later use
-        config.set('credentials', credentials);
-        // Save senderId
-        config.set('senderId', senderId);
-        // Notify the renderer process that the FCM token has changed
-        webContents.send(TOKEN_UPDATED, credentials.fcm.token);
-      }
-      // Listen for GCM/FCM notifications
-      await listen(Object.assign({}, credentials, { persistentIds }), onNotification(webContents));
-      // Notify the renderer process that we are listening for notifications
-      webContents.send(NOTIFICATION_SERVICE_STARTED, credentials.fcm.token);
-    } catch (e) {
-      console.error('PUSH_RECEIVER:::Error while starting the service', e);
-      // Forward error to the renderer process
-      webContents.send(NOTIFICATION_SERVICE_ERROR, e.message);
-    }
-  });
+    // Will be called by the renderer process
+    ipcMain.on(START_NOTIFICATION_SERVICE, async(_, senderId) => {
+        // Retrieve saved credentials
+        let credentials = config.get('credentials');
+
+        // Retrieve saved senderId
+        const savedSenderId = config.get('senderId');
+
+        if (started) {
+            webContents.send(NOTIFICATION_SERVICE_STARTED, (credentials.fcm || {}).token);
+            return;
+        }
+
+        started = true;
+
+        try {
+            // Retrieve saved persistentId : avoid receiving all already received notifications on start
+            const persistentIds = config.get('persistentIds') || [];
+
+            // Register if no credentials or if senderId has changed
+            if (!credentials || savedSenderId !== senderId) {
+                credentials = await register(senderId);
+                // Save credentials for later use
+                config.set('credentials', credentials);
+                // Save senderId
+                config.set('senderId', senderId);
+                // Notify the renderer process that the FCM token has changed
+                webContents.send(TOKEN_UPDATED, credentials.fcm.token);
+            }
+
+            // Listen for GCM/FCM notifications
+            await listen(Object.assign({}, credentials, {persistentIds}), onNotification(webContents));
+
+            // Notify the renderer process that we are listening for notifications
+            webContents.send(NOTIFICATION_SERVICE_STARTED, credentials.fcm.token);
+        } catch (e) {
+            console.error('PUSH_RECEIVER:::Error while starting the service', e);
+            // Forward error to the renderer process
+            webContents.send(NOTIFICATION_SERVICE_ERROR, e.message);
+        }
+    });
+}
+
+function reset() {
+    config.set('credentials', null);
+    config.set('senderId', null);
+    config.set('persistentIds', null);
+    started = false;
 }
 
 // Will be called on new notification
 function onNotification(webContents) {
-  return ({ notification, persistentId }) => {
-    const persistentIds = config.get('persistentIds') || [];
-    // Update persistentId
-    config.set('persistentIds', [...persistentIds, persistentId]);
-    // Notify the renderer process that a new notification has been received
-    webContents.send(NOTIFICATION_RECEIVED, notification);
-  };
+    return ({notification, persistentId}) => {
+        const persistentIds = config.get('persistentIds') || [];
+
+        // Update persistentId
+        config.set('persistentIds', [...persistentIds, persistentId]);
+
+        // Notify the renderer process that a new notification has been received
+        webContents.send(NOTIFICATION_RECEIVED, notification);
+    };
 }


### PR DESCRIPTION
This feature is necessary to allow for Electron apps that can be used to sign in and out using different accounts and allowing each user to maintain their own FCM config data.