### PR TITLE
Use CRA compatible constants

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-push-receiver",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A module to receive FCM notifications in electron",
   "main": "src/index.js",
   "repository": "https://github.com/MatthieuLemoine/electron-push-receiver",

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,18 +1,12 @@
-// Event to be sent from renderer process to trigger service start
-const START_NOTIFICATION_SERVICE = 'PUSH_RECEIVER:::START_NOTIFICATION_SERVICE';
-// Event sent to the renderer process once the service is up
-const NOTIFICATION_SERVICE_STARTED = 'PUSH_RECEIVER:::NOTIFICATION_SERVICE_STARTED';
-// Event sent to the renderer process if an error has occured during the starting process
-const NOTIFICATION_SERVICE_ERROR = 'PUSH_RECEIVER:::NOTIFICATION_SERVICE_ERROR';
-// Event sent to the renderer processs when a notification has been received
-const NOTIFICATION_RECEIVED = 'PUSH_RECEIVER:::NOTIFICATION_RECEIVED';
-// Event sent to the renderer processs when the FCM token has been updated
-const TOKEN_UPDATED = 'PUSH_RECEIVER:::TOKEN_UPDATED';
-
 module.exports = {
-  START_NOTIFICATION_SERVICE,
-  NOTIFICATION_SERVICE_STARTED,
-  NOTIFICATION_SERVICE_ERROR,
-  NOTIFICATION_RECEIVED,
-  TOKEN_UPDATED,
+  // Event to be sent from renderer process to trigger service start
+  START_NOTIFICATION_SERVICE: 'PUSH_RECEIVER:::START_NOTIFICATION_SERVICE',
+  // Event sent to the renderer process once the service is up
+  NOTIFICATION_SERVICE_STARTED: 'PUSH_RECEIVER:::NOTIFICATION_SERVICE_STARTED',
+  // Event sent to the renderer process if an error has occured during the starting process
+  NOTIFICATION_SERVICE_ERROR: 'PUSH_RECEIVER:::NOTIFICATION_SERVICE_ERROR',
+  // Event sent to the renderer processs when a notification has been received
+  NOTIFICATION_RECEIVED: 'PUSH_RECEIVER:::NOTIFICATION_RECEIVED',
+  // Event sent to the renderer processs when the FCM token has been updated
+  TOKEN_UPDATED: 'PUSH_RECEIVER:::TOKEN_UPDATED',
 };


### PR DESCRIPTION
This PR fixes an error when building with react-scripts.

```
react-scripts build

Creating an optimized production build...
Failed to compile.

Failed to minify the code from this file: 

 	./node_modules/electron-push-receiver/src/constants/index.js:13 
```

Resolves issue #16 