### PR TITLE
Notification crash for in memory macos Apps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,6 +68,9 @@ function onNotification(webContents) {
     // Update persistentId
     config.set('persistentIds', [...persistentIds, persistentId]);
     // Notify the renderer process that a new notification has been received
-    webContents.send(NOTIFICATION_RECEIVED, notification);
+    // And check if window is not destroyed for darwin Apps
+    if(!webContents.isDestroyed()){
+      webContents.send(NOTIFICATION_RECEIVED, notification);
+    }
   };
 }


### PR DESCRIPTION
Fix for darwin electron apps that are in memory and receive a notification. The webContent is destroyed causing the app to crash. (#40)
This validation prevent the notification to go through. 


