### PR TITLE
Resetting the Push Receiver feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,22 @@ ipcRenderer.on(ON_NOTIFICATION_RECEIVED, (_, notification) => // display notific
 ipcRenderer.send(START_NOTIFICATION_SERVICE, senderId);
 ```
 
+## Resetting the Push Receiver
+
+There are cases where you may need to reset the push receiver to a state where it retrieves a new notification token from FCM. For instance, if your app is designed to support a sign-in screen and you only want push notifications for the person who signs in, you will need to have the push receiver delete the notification token when a different person signs in, otherwise the new sign-in may receive notifications that are only private to the person who signed in previously.
+
+- In renderer process :
+
+```javascript
+import { ipcRenderer } from 'electron';
+import {
+  DESTROY_NOTIFICATION_SERVICE
+} from 'electron-push-receiver/src/constants';
+
+// You can invoke it on user logout
+ipcRenderer.send(DESTROY_NOTIFICATION_SERVICE);
+```
+
 ## Example
 
 Thanks to [CydeSwype](https://github.com/CydeSwype), you can find an example project [here](https://github.com/CydeSwype/electron-fcm-demo).

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,6 +1,8 @@
 module.exports = {
   // Event to be sent from renderer process to trigger service start
   START_NOTIFICATION_SERVICE: 'PUSH_RECEIVER:::START_NOTIFICATION_SERVICE',
+  // Event to be sent from renderer process to trigger service destroy
+  DESTROY_NOTIFICATION_SERVICE: 'PUSH_RECEIVER:::DESTROY_NOTIFICATION_SERVICE',
   // Event sent to the renderer process once the service is up
   NOTIFICATION_SERVICE_STARTED: 'PUSH_RECEIVER:::NOTIFICATION_SERVICE_STARTED',
   // Event sent to the renderer process if an error has occured during the starting process

--- a/src/electron-push-receiver.d.ts
+++ b/src/electron-push-receiver.d.ts
@@ -1,5 +1,6 @@
 interface ElectronPushReceiver {
     START_NOTIFICATION_SERVICE: string;
+    DESTROY_NOTIFICATION_SERVICE: string;
     NOTIFICATION_SERVICE_STARTED: string;
     NOTIFICATION_SERVICE_ERROR: string;
     NOTIFICATION_RECEIVED: string;


### PR DESCRIPTION
This feature is necessary to allow for Electron apps that can be used to sign in and out using different accounts and allowing each user to maintain their own FCM config data.

I modified [this PR](https://github.com/MatthieuLemoine/electron-push-receiver/pull/26)
where I changed the way of invoking resetting functionality to ipcRenderer and add client.destroy() to stop listening for GCM/FCM notifications when user signed out